### PR TITLE
Added wall slide support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ Use `platypus.jump()` to perform a jump and `platypus.abort_jump()` to reduce th
 			end
 		end
 	end
+    
+## Double jump, wall jump and wall slide
+Platypus supports double jumps when config.allow_double_jump is set to true. Then, it occurs automatically, when used jump() while already jumped up.
+
+Platypus supports wall jumps when config.allow_wall_jump is set to true. Then, it occurs automatically, when used jump() while having a wall_contact.
+Normally, user can alter your movement right after bounced from a wall, but when you set config.const_wall_jump - the bounce will be always the same and user won't be able to alter it.
+
+Platypus supports wall slide when config.allow_wall_slide is set to true. Then, it occurs automatically, when pushing toward a wall, while falling down. Platypus offers also to abort_wall_slide(), for example, when the control key is released, so user is no longer pushing toward the wall.
+
 
 ## Collision detection
 Platypus uses either collision shapes or ray casts to detect collisions (configured when creating a Platypus instance). In both cases ray casts are used to detect wall and ground contact.
@@ -108,6 +117,8 @@ Platypus will send messages for certain state changes so that scripts can react,
 			print("Doing a double jump!")
 		elseif message_id == platypus.JUMP then
 			print("Jumping!")
+        elseif message_id == platypus.WALL_SLIDE then
+			print("Sliding down a wall!")
 		end
 	end
 
@@ -134,7 +145,7 @@ The ```config``` table can have the following values:
 * `allow_wall_jump` (boolean) - If wall jumps are allowed (OPTIONAL)
 * `const_wall_jump` (boolean) - If true - prevents user from changing velocity while bounced from a wall. Set to false by default, to keep legacy behavior. (OPTIONAL)
 * `allow_wall_slide` (boolean) - If true - wall slide is allowed (by pushing forward on a wall while falling) (OPTIONAL)
-* `wall_slide_velocity` (boolean) - "gravity" that applies when sliding down the wall (generally should be lower than overall gravity, to simulate sliding) (OPTIONAL)
+* `wall_slide_velocity` (number) - "gravity" that applies when sliding down the wall (generally should be lower than overall gravity, to simulate sliding) (OPTIONAL)
 
 The `collisions` table can have the following values:
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ The ```config``` table can have the following values:
 * `max_velocity` (number) - Maximum velocity of the game object (pixels/s). Set this to limit speed and prevent full penetration of game object into level geometry (OPTIONAL)
 * `wall_jump_power_ratio_x` (number) - Amount to multiply the jump power with when applying horizontal velocity during a wall jump (OPTIONAL)
 * `wall_jump_power_ratio_y` (number) - Amount to multiply the jump power with when applying vertical velocity during a wall jump (OPTIONAL)
-* `allow_double_jump` (boolean) - If double jumps are allowed
-* `allow_wall_jump` (boolean) - If wall jumps are allowed
-* `const_wall_jump` (boolean) - If true - prevents user from changing velocity while bounced from a wall. Set to false by default, to keep legacy behavior.
+* `allow_double_jump` (boolean) - If double jumps are allowed (OPTIONAL)
+* `allow_wall_jump` (boolean) - If wall jumps are allowed (OPTIONAL)
+* `const_wall_jump` (boolean) - If true - prevents user from changing velocity while bounced from a wall. Set to false by default, to keep legacy behavior. (OPTIONAL)
+* `allow_wall_slide` (boolean) - If true - wall slide is allowed (by pushing forward on a wall while falling) (OPTIONAL)
+* `wall_slide_velocity` (boolean) - "gravity" that applies when sliding down the wall (generally should be lower than overall gravity, to simulate sliding) (OPTIONAL)
 
 The `collisions` table can have the following values:
 
@@ -218,17 +220,23 @@ Make the game object perform a jump. Depending on state and configuration, this 
 **PARAMETERS**
 * `power` (number) - Initial takeoff speed (pixels/s)
 
+
 ### instance.force_jump(power)
 Make the game object perform a jump, regardless of current state.
 
 **PARAMETERS**
 * `power` (number) - Initial takeoff speed (pixels/s)
 
+
 ### instance.abort_jump(reduction)
 Abort a jump by "cutting it short". This will reduce the vertical speed by some fraction.
 
 **PARAMETERS**
 * `reduction` (number) - Amount to multiply vertical velocity with
+
+
+### instance.abort_wall_slide()
+Abort a slide down a wall (could be used when releasing the pushing control key)
 
 
 ### instance.has_ground_contact()
@@ -258,11 +266,19 @@ Check if the game object is jumping. The game object is considered falling if no
 **RETURN**
 * `jumping` (boolean) - True if jumping
 
+
 ### instance.is_wall_jumping()
 Check if the game object is jumping after a bounce from a wall. The game object is considered falling if not having ground contact and velocity is pointing up.
 
 **RETURN**
 * `wall_jump` (boolean) - True if jumping after a bounce from a wall.
+
+
+### instance.is_wall_sliding()
+Check if the game object is sliding down a wall.
+
+**RETURN**
+* `wall_slide` (boolean) - True if sliding down a wall.
 
 
 ### instance.toggle_debug()
@@ -288,6 +304,9 @@ Sent when the game object performs a wall jump
 
 ### platypus.DOUBLE_JUMP
 Sent when the game object performs a double jump
+
+### platypus.WALL_SLIDE
+Sent when the game object starts sliding down a wall
 
 
 ## Constants

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The ```config``` table can have the following values:
 * `wall_jump_power_ratio_y` (number) - Amount to multiply the jump power with when applying vertical velocity during a wall jump (OPTIONAL)
 * `allow_double_jump` (boolean) - If double jumps are allowed
 * `allow_wall_jump` (boolean) - If wall jumps are allowed
+* `const_wall_jump` (boolean) - If true - prevents user from changing velocity while bounced from a wall. Set to false by default, to keep legacy behavior.
 
 The `collisions` table can have the following values:
 
@@ -256,6 +257,12 @@ Check if the game object is jumping. The game object is considered falling if no
 
 **RETURN**
 * `jumping` (boolean) - True if jumping
+
+### instance.is_wall_jumping()
+Check if the game object is jumping after a bounce from a wall. The game object is considered falling if not having ground contact and velocity is pointing up.
+
+**RETURN**
+* `wall_jump` (boolean) - True if jumping after a bounce from a wall.
 
 
 ### instance.toggle_debug()

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Use `platypus.jump()` to perform a jump and `platypus.abort_jump()` to reduce th
 	end
     
 ## Double jump, wall jump and wall slide
-Platypus supports double jumps when config.allow_double_jump is set to true. Then, it occurs automatically, when used jump() while already jumped up.
+Platypus supports double jumps when config.allow_double_jump is set to true. A double jump is performed automatically when a second jump is done before and up until reaching the apex of the first jump. It is not possible to perform a double jump when falling
 
-Platypus supports wall jumps when config.allow_wall_jump is set to true. Then, it occurs automatically, when used jump() while having a wall_contact.
+Platypus supports wall jumps when config.allow_wall_jump is set to true. A wall jump is performed automatically when jumping while having wall contact while falling or wall sliding. The wall jump pushes the player out from the wall in question.
 Normally, user can alter your movement right after bounced from a wall, but when you set config.const_wall_jump - the bounce will be always the same and user won't be able to alter it.
 
-Platypus supports wall slide when config.allow_wall_slide is set to true. Then, it occurs automatically, when pushing toward a wall, while falling down. Platypus offers also to abort_wall_slide(), for example, when the control key is released, so user is no longer pushing toward the wall.
+Platypus supports wall slide when config.allow_wall_slide is set to true. A wall slide will be performed automatically when the player has wall contact while falling and moving (using platypus.left() or platypus.right()) in the direction of the wall. Platypus offers also to abort_wall_slide(), for example, when the control key is released, so user is no longer pushing toward the wall.
 
 
 ## Collision detection

--- a/example/grottoescape/player.script
+++ b/example/grottoescape/player.script
@@ -38,12 +38,14 @@ function init(self)
 				[hash("onewayplatform")] = platypus.DIR_DOWN,
 				[hash("onewaydoor")] = platypus.DIR_LEFT,
 			},
-			left = 7, right = 7, top = 6, bottom = 8, offset = vmath.vector3(0, 8, 0)
+			left = 7, right = 7, top = 7, bottom = 7, offset = vmath.vector3(0, 7, 0)
 		},
 		gravity = -800,
 		max_velocity = 580,
 		allow_double_jump = true,
 		allow_wall_jump = true,
+		allow_wall_slide = true,
+		wall_slide_gravity = -50
 		--debug = true,
 	})
 	self.current_animation = nil
@@ -61,6 +63,7 @@ function update(self, dt)
 		play_animation(self, ground_contact and ANIM_RUN or ANIM_JUMP)
 		sprite.set_hflip("#sprite", false)
 	else
+		self.platypus.abort_wall_slide()
 		play_animation(self, ground_contact and ANIM_IDLE or ANIM_JUMP)
 	end
 	self.platypus.update(dt)

--- a/game.project
+++ b/game.project
@@ -43,3 +43,6 @@ package = com.britzl.defold.platypus
 [osx]
 bundle_identifier = com.britzl.defold.platypus
 
+[tilemap]
+max_tile_count = 4096
+

--- a/platypus/platypus.lua
+++ b/platypus/platypus.lua
@@ -297,7 +297,7 @@ function M.create(config)
 			elseif (platypus.const_wall_jump and not state.current.wall_jump) or (not platypus.const_wall_jump) then
 				movement.x = velocity
 			end
-		elseif state.current.wall_contact ~= 1 and platypus.allow_wall_slide and platypus.is_falling() and not state.current.wall_slide then	-- (and pushes on the wall)
+		elseif state.current.wall_contact ~= 1 and platypus.allow_wall_slide and platypus.is_falling() and not state.current.wall_slide then
 			state.current.wall_slide = true
 			state.previous.wall_slide = true
 			msg.post("#", M.WALL_SLIDE)			-- notify about starting wall slide
@@ -335,7 +335,7 @@ function M.create(config)
 	end
 
 	--- Try to make the game object jump.
-	-- @param power The power of the jump (ie how high)x`
+	-- @param power The power of the jump (ie how high)
 	function platypus.jump(power)
 		assert(power, "You must provide a jump takeoff power")
 		if state.current.ground_contact then

--- a/platypus/platypus.lua
+++ b/platypus/platypus.lua
@@ -537,10 +537,7 @@ function M.create(config)
 
 		-- reset wall slide and wall jump when standing on the ground
 		if state.current.ground_contact then
-			if state.current.wall_slide then
-				state.current.wall_slide = false
-				state.previous.wall_slide = false
-			end
+			platypus.abort_wall_slide()
 			if state.current.wall_jump then
 				state.current.wall_jump = false
 				state.previous.wall_jump = false
@@ -579,9 +576,8 @@ function M.create(config)
 		end
 
 		-- abort wall slide when lost contact with the wall while sliding
-		if not state.current.wall_contact and state.current.wall_slide then
-			state.current.wall_slide = false
-			state.previous.wall_slide = false
+		if not state.current.wall_contact then
+			platypus.abort_wall_slide()
 		end
 
 		-- notify ground or air state change

--- a/platypus/platypus.lua
+++ b/platypus/platypus.lua
@@ -21,6 +21,7 @@ M.FALLING = hash("platypus_falling")
 M.GROUND_CONTACT = hash("platypus_ground_contact")
 M.WALL_CONTACT = hash("platypus_wall_contact")
 M.WALL_JUMP = hash("platypus_wall_jump")
+M.WALL_SLIDE = hash("platypus_wall_slide")
 M.DOUBLE_JUMP = hash("platypus_double_jump")
 M.JUMP = hash("platypus_jump")
 
@@ -35,6 +36,8 @@ local ALLOWED_CONFIG_KEYS = {
 	allow_wall_jump = true,
 	const_wall_jump = true,
 	allow_double_jump = true,
+	allow_wall_slide = true,
+	wall_slide_gravity = true,
 	max_velocity = true,
 	gravity = true,
 	debug = true,
@@ -92,6 +95,8 @@ function M.create(config)
 		allow_double_jump = config.allow_double_jump or false,
 		allow_wall_jump = config.allow_wall_jump or false,
 		const_wall_jump = config.const_wall_jump or false,
+		allow_wall_slide = config.allow_wall_slide or false,
+		wall_slide_gravity = config.wall_slide_gravity or -50,
 		collisions = config.collisions,
 		debug = config.debug,
 	}
@@ -109,12 +114,11 @@ function M.create(config)
 
 	-- track current and previous state to detect state changes
 	local function create_state()
-		return { wall_contact = false, wall_jump = false, ground_contact = false, rays = {}, down_rays = {} }
+		return { wall_contact = false, wall_jump = false, wall_slide = false, ground_contact = false, rays = {}, down_rays = {} }
 	end
 	local state = {}
 	state.current = create_state()
 	state.previous = create_state()
-
 
 	-- movement based on user input
 	local movement = vmath.vector3()
@@ -264,6 +268,11 @@ function M.create(config)
 			elseif (platypus.const_wall_jump and not state.current.wall_jump) or (not platypus.const_wall_jump) then
 				movement.x = -velocity
 			end
+		elseif state.current.wall_contact ~= -1 and platypus.allow_wall_slide and platypus.is_falling() and not state.current.wall_slide then
+			state.current.wall_slide = true
+			state.previous.wall_slide = true
+			msg.post("#", M.WALL_SLIDE)			-- notify about starting wall slide
+			platypus.velocity.y = 0				-- reduce vertical speed
 		end
 	end
 
@@ -288,6 +297,11 @@ function M.create(config)
 			elseif (platypus.const_wall_jump and not state.current.wall_jump) or (not platypus.const_wall_jump) then
 				movement.x = velocity
 			end
+		elseif state.current.wall_contact ~= 1 and platypus.allow_wall_slide and platypus.is_falling() and not state.current.wall_slide then	-- (and pushes on the wall)
+			state.current.wall_slide = true
+			state.previous.wall_slide = true
+			msg.post("#", M.WALL_SLIDE)			-- notify about starting wall slide
+			platypus.velocity.y = 0				-- reduce vertical speed
 		end
 	end
 
@@ -312,8 +326,16 @@ function M.create(config)
 		movement = velocity
 	end
 
+	--- Abort a wall slide
+	function platypus.abort_wall_slide()
+		if state.current.wall_slide then
+			state.current.wall_slide = false
+			state.previous.wall_slide = false
+		end
+	end
+
 	--- Try to make the game object jump.
-	-- @param power The power of the jump (ie how high)
+	-- @param power The power of the jump (ie how high)x`
 	function platypus.jump(power)
 		assert(power, "You must provide a jump takeoff power")
 		if state.current.ground_contact then
@@ -324,6 +346,11 @@ function M.create(config)
 		elseif state.current.wall_contact and platypus.allow_wall_jump then
 			state.current.wall_jump = true
 			state.previous.wall_jump = true
+			-- abort wall sliding when jumping from wall
+			if state.current.wall_slide then
+				state.current.wall_slide = false
+				state.previous.wall_slide = false
+			end
 			platypus.velocity.y = power * platypus.wall_jump_power_ratio_y
 			platypus.velocity.x = state.current.wall_contact * power * platypus.wall_jump_power_ratio_x
 			msg.post("#", M.WALL_JUMP)
@@ -361,6 +388,12 @@ function M.create(config)
 	-- @return true if jumping from wall
 	function platypus.is_wall_jumping()
 		return state.current.wall_jump and jumping_up()
+	end
+
+	--- Check if this object is sliding on a wall
+	-- @return true if sliding on a wall
+	function platypus.is_wall_sliding()
+		return state.current.wall_slide
 	end
 
 	--- Check if this object is falling
@@ -499,12 +532,25 @@ function M.create(config)
 			end
 		end
 
-		-- apply gravity if not standing on the ground
-		if not state.current.ground_contact then
+		-- apply wall slide velocity
+		if state.current.wall_slide then
+			platypus.velocity.y = platypus.velocity.y + platypus.wall_slide_gravity * dt
+
+			-- apply gravity if not standing on the ground
+		elseif not state.current.ground_contact then
 			platypus.velocity.y = platypus.velocity.y + platypus.gravity * dt
-		elseif state.current.wall_jump then
-			state.current.wall_jump = false
-			state.previous.wall_jump = false
+		end
+
+		-- reset wall slide and wall jump when standing on the ground
+		if state.current.ground_contact then
+			if state.current.wall_slide then
+				state.current.wall_slide = false
+				state.previous.wall_slide = false
+			end
+			if state.current.wall_jump then
+				state.current.wall_jump = false
+				state.previous.wall_jump = false
+			end
 		end
 
 		-- update and clamp velocity
@@ -536,6 +582,12 @@ function M.create(config)
 		-- notify wall contact state change
 		if state.current.wall_contact and not state.previous.wall_contact then
 			msg.post("#", M.WALL_CONTACT)
+		end
+
+		-- abort wall slide when lost contact with the wall while sliding
+		if not state.current.wall_contact and state.current.wall_slide then
+			state.current.wall_slide = false
+			state.previous.wall_slide = false
 		end
 
 		-- notify ground or air state change

--- a/platypus/platypus.lua
+++ b/platypus/platypus.lua
@@ -346,11 +346,7 @@ function M.create(config)
 		elseif state.current.wall_contact and platypus.allow_wall_jump then
 			state.current.wall_jump = true
 			state.previous.wall_jump = true
-			-- abort wall sliding when jumping from wall
-			if state.current.wall_slide then
-				state.current.wall_slide = false
-				state.previous.wall_slide = false
-			end
+			platypus.abort_wall_slide()		-- abort wall sliding when jumping from wall
 			platypus.velocity.y = power * platypus.wall_jump_power_ratio_y
 			platypus.velocity.x = state.current.wall_contact * power * platypus.wall_jump_power_ratio_x
 			msg.post("#", M.WALL_JUMP)
@@ -532,11 +528,9 @@ function M.create(config)
 			end
 		end
 
-		-- apply wall slide gravity
+		-- apply wall slide gravity or normal gravity if not standing on the ground
 		if state.current.wall_slide then
 			platypus.velocity.y = platypus.velocity.y + platypus.wall_slide_gravity * dt
-
-                -- apply gravity if not standing on the ground
 		elseif not state.current.ground_contact then
 			platypus.velocity.y = platypus.velocity.y + platypus.gravity * dt
 		end


### PR DESCRIPTION
**Added wall slide support.** 

Platypus, when `config.allow_wall_slide` is `true`, can now handle wall slide with a mutable `config.wall_slide_gravity`, which simulates sliding slowly down a wall. It notifies game object about starting wall slide with a message `platypus.WALL_SLIDE` and user can check if it `is_wall_sliding()`. Added this possibility to the example project. Fixed collision rays in example's config. Added `abort_wall_slide()` when control keys are released. Updated readme with new functionality informations and general double and wall jumps and wall slide.