### PR TITLE
Add collision around player to detect ground collisions

### DIFF
--- a/example/grottoescape/player.go
+++ b/example/grottoescape/player.go
@@ -81,3 +81,51 @@ embedded_components {
     w: 1.0
   }
 }
+embedded_components {
+  id: "playercollider"
+  type: "collisionobject"
+  data: "collision_shape: \"\"\n"
+  "type: COLLISION_OBJECT_TYPE_KINEMATIC\n"
+  "mass: 0.0\n"
+  "friction: 0.1\n"
+  "restitution: 0.5\n"
+  "group: \"player\"\n"
+  "mask: \"ground\"\n"
+  "embedded_collision_shape {\n"
+  "  shapes {\n"
+  "    shape_type: TYPE_BOX\n"
+  "    position {\n"
+  "      x: 0.0\n"
+  "      y: 8.0\n"
+  "      z: 0.0\n"
+  "    }\n"
+  "    rotation {\n"
+  "      x: 0.0\n"
+  "      y: 0.0\n"
+  "      z: 0.0\n"
+  "      w: 1.0\n"
+  "    }\n"
+  "    index: 0\n"
+  "    count: 3\n"
+  "  }\n"
+  "  data: 9.0305\n"
+  "  data: 9.0305\n"
+  "  data: 10.0\n"
+  "}\n"
+  "linear_damping: 0.0\n"
+  "angular_damping: 0.0\n"
+  "locked_rotation: false\n"
+  "bullet: false\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+}


### PR DESCRIPTION
Allows us to interact with objects such as destroyable platforms. Is not working especially with the destroyable platforms in the demo. The destroyable platform is now able to destroy itself.