### PR TITLE
Fix for abnormal high delta time values

### DIFF
--- a/platypus/platypus.lua
+++ b/platypus/platypus.lua
@@ -465,6 +465,10 @@ function M.create(config)
 	-- @param dt
 	function platypus.update(dt)
 		assert(dt, "You must provide a delta time")
+		-- ignore high delta time values (that may appear when window focus is lost)
+		if (dt > 0.1) then
+			dt = 0.016 -- assuming 60 FPS
+		end
 
 		-- was the ground we're standing on removed?
 		if config.reparent and state.parent_id then


### PR DESCRIPTION
This fixes problems that appear as character falling through a platform, when window focus is lost for a moment (for example moving window, minimizing and maximizing, etc). Values in the commit are totally arbitrary, but works all the time, tested on a few projects.